### PR TITLE
Remove locale

### DIFF
--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -63,7 +63,6 @@ module Moirai
       end
 
       translation = Translation.new(translation_params)
-      translation.locale = @file_handler.get_first_key(translation_params[:file_path])
       if translation.save
         flash.notice = "Translation #{translation.key} was successfully created."
       else

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -2,7 +2,7 @@
 
 module Moirai
   class Translation < Moirai::ApplicationRecord
-    validates_presence_of :key, :locale, :file_path
+    validates_presence_of :key, :file_path
     validate :file_path_must_exist
 
     private

--- a/app/models/moirai/translation_dumper.rb
+++ b/app/models/moirai/translation_dumper.rb
@@ -21,8 +21,10 @@ module Moirai
 
       yaml = YAML.load_file(file_path)
 
+      root_key = yaml.keys.first
+
       translations.each do |translation|
-        keys = [translation.locale] + translation.key.split(".")
+        keys = [root_key] + translation.key.split(".")
 
         node = yaml
 

--- a/lib/generators/moirai/templates/migration.rb.erb
+++ b/lib/generators/moirai/templates/migration.rb.erb
@@ -1,7 +1,6 @@
 class CreateMoiraiTranslations < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :moirai_translations do |t|
-      t.string :locale, null: false
       t.string :key, null: false
       t.string :file_path, null: false
       t.text :value

--- a/test/dummy/db/migrate/20241022085549_create_moirai_translations.rb
+++ b/test/dummy/db/migrate/20241022085549_create_moirai_translations.rb
@@ -2,7 +2,6 @@ class CreateMoiraiTranslations < ActiveRecord::Migration[7.2]
   def change
     create_table :moirai_translations do |t|
       t.string :file_path, null: false
-      t.string :locale, null: false
       t.string :key, null: false
       t.text :value
       t.timestamps

--- a/test/models/translation_test.rb
+++ b/test/models/translation_test.rb
@@ -19,12 +19,6 @@ module Moirai
       assert_includes @valid_translation.errors[:key], "can't be blank"
     end
 
-    test "should be invalid without locale" do
-      @valid_translation.locale = nil
-      assert_not @valid_translation.valid?
-      assert_includes @valid_translation.errors[:locale], "can't be blank"
-    end
-
     test "should be invalid without file_path" do
       @valid_translation.file_path = nil
       assert_not @valid_translation.valid?


### PR DESCRIPTION
Locale column in `Translation` model is not needed and only caused confusion. It should thus be removed.

## Todo
- [ ] Check what we can do about historical migrations? Can I just update them or should I create a new migration that drops the column? @oliveranthony17 @coorasse?