### PR TITLE
Fix missing translations

### DIFF
--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -39,6 +39,14 @@ module Moirai
     end
 
     def handle_update(translation)
+
+      if translation.value.blank?
+        translation.destroy
+        flash.notice = "Translation #{translation.key} was successfully deleted."
+        redirect_to_translation_file(translation.file_path)
+        return
+      end
+
       if File.exist? translation_params[:file_path]
         translation_from_file = @file_handler.parse_file(translation_params[:file_path])
         if translation_from_file[translation.key] == translation_params[:value] || translation_params[:value].blank?

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -39,7 +39,6 @@ module Moirai
     end
 
     def handle_update(translation)
-
       if translation.value.blank?
         translation.destroy
         flash.notice = "Translation #{translation.key} was successfully deleted."

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -39,7 +39,7 @@ module Moirai
     end
 
     def handle_update(translation)
-      if translation.value.blank?
+      if translation.value.strip.blank?
         translation.destroy
         flash.notice = "Translation #{translation.key} was successfully deleted."
         redirect_to_translation_file(translation.file_path)
@@ -48,7 +48,7 @@ module Moirai
 
       if File.exist? translation_params[:file_path]
         translation_from_file = @file_handler.parse_file(translation_params[:file_path])
-        if translation_from_file[translation.key] == translation_params[:value] || translation_params[:value].blank?
+        if translation_from_file[translation.key].strip == translation_params[:value].strip
           translation.destroy
           flash.notice = "Translation #{translation.key} was successfully deleted."
           redirect_to_translation_file(translation.file_path)

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -18,7 +18,7 @@ module Moirai
     end
 
     def create_or_update
-      if (translation = Translation.find_by(file_path: translation_params[:file_path], key: translation_params[:key]))
+      if (translation = Translation.find_by(file_path: existing_or_invented_path(translation_params[:file_path]), translation_params[:locale] || I18n.locale), key: translation_params[:key]))
         handle_update(translation)
       else
         handle_create
@@ -34,8 +34,12 @@ module Moirai
 
     private
 
+    def existing_or_invented_path(file_path)
+      File.exist?(file_path) ? file_path : invent_file_path(translation_params[:key], translation_params[:locale] || I18n.locale)
+    end
+
     def handle_update(translation)
-      translation_from_file = @file_handler.parse_file(translation_params[:file_path])
+      translation_from_file = File.exist?(translation_params[:file_path]) ? @file_handler.parse_file(translation_params[:file_path]) : {}
       if translation_from_file[translation.key] == translation_params[:value] || translation_params[:value].blank?
         translation.destroy
         flash.notice = "Translation #{translation.key} was successfully deleted."
@@ -53,29 +57,31 @@ module Moirai
     end
 
     def handle_create
-      binding.irb
       unless translation_params[:file_path].present?
         locale = translation_params[:locale] || I18n.locale
         key = translation_params[:key] || I18n.locale
         translation_params[:file_path] = Rails.root.join("locales", "moirai_#{locale}_#{key}.yml").to_s
       end
 
-      if File.exists?(translation_params[:file_path])
+
+      if File.exist?(translation_params[:file_path])
         translation_from_file = @file_handler.parse_file(translation_params[:file_path])
         if translation_from_file[translation_params[:key]] == translation_params[:value]
-          flash.alert = "Translation #{translation_params[:key]} already exists."
+          flash.alert = "Translation #{translation_params[:key]} already exist."
           redirect_to_translation_file(translation_params[:file_path])
           return
         end
       end
 
       translation = Translation.new(translation_params)
-      translation.file_path ||= invent_file_path(translation.locale, translation.key)
-      translation.locale = File.exists? translation.file_path ? @file_handler.get_first_key(translation_params[:file_path]) : translation.locale
-
-      if translation.save
+      if translation.file_path.blank?
+        translation.file_path = invent_file_path(translation.locale, translation.key)
+      end
+      translation.locale = File.exist?(translation.file_path ) ? @file_handler.get_first_key(translation.file_path) : I18n.locale.to_s
+      if translation.save!
         flash.notice = "Translation #{translation.key} was successfully created."
       else
+        Rails.logger.error(translation.errors.full_messages)
         flash.alert = translation.errors.full_messages.join(", ")
       end
 
@@ -83,7 +89,7 @@ module Moirai
     end
 
     def invent_file_path(locale, key)
-      Rails.root.join("locales", "moirai_#{locale}_#{key}.yml").to_s
+      Rails.root.join("config", "locales", "moirai_#{locale}_#{key}.yml").to_s
     end
 
     def redirect_to_translation_file(file_path)
@@ -106,3 +112,8 @@ module Moirai
     end
   end
 end
+
+
+## Translations
+
+# 1. Update inline translation (key=)

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -102,9 +102,7 @@ module Moirai
     end
 
     def translation_params
-      strong_params = params.require(:translation).permit(:key, :value, :file_path)
-      strong_params[:file_path] ||= invent_file_path(strong_params[:locale], strong_params[:key])
-      strong_params
+      params.require(:translation).permit(:key, :value, :file_path)
     end
 
     def load_file_handler

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -8,7 +8,7 @@ module Moirai
     private
 
     def file_path_must_exist
-      errors.add(:file_path, "must exist") unless file_path && File.exist?(file_path)
+      # errors.add(:file_path, "must exist") unless file_path && File.exist?(file_path)
     end
   end
 end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -2,7 +2,7 @@
 
 module Moirai
   class Translation < Moirai::ApplicationRecord
-    validates_presence_of :key, :locale, :file_path
+    validates_presence_of :key, :file_path
     validate :file_path_must_exist
 
     private

--- a/app/models/moirai/translation_dumper.rb
+++ b/app/models/moirai/translation_dumper.rb
@@ -21,7 +21,7 @@ module Moirai
 
       root_key = File.exist?(file_path) ? YAML.load_file(file_path).keys.first : I18n.locale
 
-      yaml = File.exist?(file_path) ? YAML.load_file(file_path) : { root_key => {} }
+      yaml = File.exist?(file_path) ? YAML.load_file(file_path) : {root_key => {}}
 
       translations.each do |translation|
         keys = [root_key] + translation.key.split(".")

--- a/app/models/moirai/translation_dumper.rb
+++ b/app/models/moirai/translation_dumper.rb
@@ -19,10 +19,12 @@ module Moirai
     def get_updated_file_contents(file_path)
       translations = Moirai::Translation.where(file_path: file_path)
 
-      yaml = YAML.load_file(file_path)
+      root_key = File.exist?(file_path) ? YAML.load_file(file_path).keys.first : I18n.locale
+
+      yaml = File.exist?(file_path) ? YAML.load_file(file_path) : { root_key => {} }
 
       translations.each do |translation|
-        keys = [translation.locale] + translation.key.split(".")
+        keys = [root_key] + translation.key.split(".")
 
         node = yaml
 

--- a/lib/i18n/backend/moirai.rb
+++ b/lib/i18n/backend/moirai.rb
@@ -3,7 +3,7 @@ module I18n
     class Moirai < I18n::Backend::Simple # TODO: no need to extend the simple one. It does too much
       # TODO: mega inefficient. we don't want to perform a SQL query for each key!
       def translate(locale, key, options = EMPTY_HASH)
-        overridden_translation = ::Moirai::Translation.find_by(key: key)
+        overridden_translation = ::Moirai::Translation.find_by(locale: locale, key: key)
         if overridden_translation.present?
           overridden_translation.value
         end

--- a/lib/i18n/backend/moirai.rb
+++ b/lib/i18n/backend/moirai.rb
@@ -3,7 +3,7 @@ module I18n
     class Moirai < I18n::Backend::Simple # TODO: no need to extend the simple one. It does too much
       # TODO: mega inefficient. we don't want to perform a SQL query for each key!
       def translate(locale, key, options = EMPTY_HASH)
-        overridden_translation = ::Moirai::Translation.find_by(locale: locale, key: key)
+        overridden_translation = ::Moirai::Translation.find_by(key: key)
         if overridden_translation.present?
           overridden_translation.value
         end

--- a/test/models/translation_test.rb
+++ b/test/models/translation_test.rb
@@ -19,23 +19,10 @@ module Moirai
       assert_includes @valid_translation.errors[:key], "can't be blank"
     end
 
-    test "should be invalid without locale" do
-      @valid_translation.locale = nil
-      assert_not @valid_translation.valid?
-      assert_includes @valid_translation.errors[:locale], "can't be blank"
-    end
-
     test "should be invalid without file_path" do
       @valid_translation.file_path = nil
       assert_not @valid_translation.valid?
       assert_includes @valid_translation.errors[:file_path], "can't be blank"
-    end
-
-    test "should be invalid if file_path does not exist" do
-      File.stub :exist?, false do
-        assert_not @invalid_translation.valid?
-        assert_includes @invalid_translation.errors[:file_path], "must exist"
-      end
     end
   end
 end


### PR DESCRIPTION
Previously, missing translations for locales could not be updated.
Example: adding a new locale.

Now the file path gets invented if the file does not already exist.

## Todo

- [ ] Check if yaml dumper actually works
- [ ] Check implementation for gem translations