### PR TITLE
Refactor file paths

### DIFF
--- a/app/assets/javascripts/moirai_translation_controller.js
+++ b/app/assets/javascripts/moirai_translation_controller.js
@@ -6,7 +6,7 @@ export default class MoiraiTranslationController extends Controller {
   }
 
   submit(event) {
-    const {filePath, key} = event.target.dataset
+    const {key} = event.target.dataset
 
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content
 
@@ -19,8 +19,7 @@ export default class MoiraiTranslationController extends Controller {
       },
       body: JSON.stringify({
         translation: {
-          key: key,
-          file_path: filePath,
+          key,
           value: event.target.innerText
         }
       })

--- a/app/assets/javascripts/moirai_translation_controller.js
+++ b/app/assets/javascripts/moirai_translation_controller.js
@@ -20,6 +20,7 @@ export default class MoiraiTranslationController extends Controller {
       body: JSON.stringify({
         translation: {
           key,
+          locale: event.target.dataset.locale,
           value: event.target.innerText
         }
       })

--- a/app/assets/javascripts/moirai_translation_controller.js
+++ b/app/assets/javascripts/moirai_translation_controller.js
@@ -1,16 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class MoiraiTranslationController extends Controller {
+  static values = {
+    key: String,
+    locale: String
+  }
+
   click(event) {
     event.preventDefault()
   }
 
   submit(event) {
-    const {key} = event.target.dataset
-
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content
 
-    fetch(`/moirai/translation_files`, {
+    fetch('/moirai/translation_files', {
       method: 'POST',
       headers: {
         'X-CSRF-Token': csrfToken,
@@ -19,8 +22,8 @@ export default class MoiraiTranslationController extends Controller {
       },
       body: JSON.stringify({
         translation: {
-          key,
-          locale: event.target.dataset.locale,
+          key: this.keyValue,
+          locale: this.localeValue
           value: event.target.innerText
         }
       })

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -100,7 +100,7 @@ module Moirai
     end
 
     def translation_params
-      params.require(:translation).permit(:key, :locale, :value, :file_path)
+      params.require(:translation).permit(:key, :locale, :value)
     end
 
     def load_file_handler

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -37,12 +37,6 @@ module Moirai
     private
 
     def handle_update(translation)
-      unless File.exist?(translation.find_file_path)
-        flash.alert = "Locale file could not be found for #{translation.key}"
-        redirect_to moirai_translation_files_path, status: :unprocessable_entity
-        return
-      end
-
       if translation_params[:value].blank? || translation_same_as_in_file?(translation.key, translation_params[:value], translation.find_file_path)
         translation.destroy
         flash.notice = "Translation #{translation.key} was successfully deleted."

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -55,7 +55,6 @@ module Moirai
 
     def handle_create
       file_path = KeyFinder.new.file_path_for(translation_params[:key], locale: translation_params[:locale])
-
       if translation_same_as_in_file?
         flash.alert = "Translation #{translation_params[:key]} already exists."
         redirect_to_translation_file(file_path)
@@ -70,7 +69,12 @@ module Moirai
         success_response(translation)
       else
         flash.alert = translation.errors.full_messages.join(", ")
-        redirect_to moirai_translation_file_path(Digest::SHA256.hexdigest(file_path))
+        if file_path.present?
+          flash.alert = "Translation #{translation.key} already exists."
+          redirect_back_or_to moirai_translation_file_path(Digest::SHA256.hexdigest(file_path))
+        else
+          redirect_back_or_to moirai_translation_files_path, status: :unprocessable_entity
+        end
       end
     end
 

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -16,7 +16,7 @@ module Moirai
     def show
       @translation_keys = @file_handler.parse_file(@decoded_path)
       @locale = @file_handler.get_first_key(@decoded_path)
-      @translations = Moirai::Translation.find_by_file_path(@decoded_path)
+      @translations = Moirai::Translation.by_file_path(@decoded_path)
     end
 
     def create_or_update
@@ -91,6 +91,11 @@ module Moirai
 
     def set_translation_file
       @file_path = @file_handler.file_hashes[params[:id]]
+      if @file_path.nil?
+        flash.alert = "File not found"
+        redirect_to moirai_translation_files_path, status: :not_found
+        return
+      end
       @decoded_path = CGI.unescape(@file_path)
     end
 

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -54,11 +54,6 @@ module Moirai
     end
 
     def handle_create
-      if translation_params[:value].blank?
-        flash.alert = "Translation value can't be blank."
-        return
-      end
-
       file_path = KeyFinder.new.file_path_for(translation_params[:key], locale: translation_params[:locale])
 
       if translation_same_as_in_file?
@@ -75,7 +70,7 @@ module Moirai
         success_response(translation)
       else
         flash.alert = translation.errors.full_messages.join(", ")
-        redirect_to moirai_translation_files_path, status: :unprocessable_entity
+        redirect_to moirai_translation_file_path(Digest::SHA256.hexdigest(file_path))
       end
     end
 

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -37,7 +37,7 @@ module Moirai
     private
 
     def handle_update(translation)
-      if translation_params[:value].blank? || translation_same_as_in_file?(translation.key, translation_params[:value], translation.find_file_path)
+      if translation_params[:value].blank? || translation_same_as_in_file?
         translation.destroy
         flash.notice = "Translation #{translation.key} was successfully deleted."
         redirect_to_translation_file(translation.find_file_path)
@@ -56,7 +56,7 @@ module Moirai
     def handle_create
       file_path = KeyFinder.new.file_path_for(translation_params[:key], locale: translation_params[:locale])
 
-      if translation_same_as_in_file?(translation_params[:key], translation_params[:value], file_path)
+      if translation_same_as_in_file?
         flash.alert = "Translation #{translation_params[:key]} already exists."
         redirect_to_translation_file(file_path)
         return
@@ -107,11 +107,13 @@ module Moirai
       @file_handler = Moirai::TranslationFileHandler.new
     end
 
-    def translation_same_as_in_file?(key, value, file_path)
+    def translation_same_as_in_file?
+      file_path = KeyFinder.new.file_path_for(translation_params[:key], locale: translation_params[:locale])
+
       return false if file_path.blank?
       return false unless File.exist?(file_path)
 
-      value == @file_handler.parse_file(file_path)[key]
+      translation_params[:value] == @file_handler.parse_file(file_path)[translation_params[:key]]
     end
   end
 end

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -14,9 +14,9 @@ module Moirai
     end
 
     def show
-      @translation_keys = @file_handler.parse_file(@decoded_path)
-      @locale = @file_handler.get_first_key(@decoded_path)
-      @translations = Moirai::Translation.by_file_path(@decoded_path)
+      @translation_keys = @file_handler.parse_file(@file_path)
+      @locale = @file_handler.get_first_key(@file_path)
+      @translations = Moirai::Translation.by_file_path(@file_path)
     end
 
     def create_or_update
@@ -90,13 +90,11 @@ module Moirai
     end
 
     def set_translation_file
-      @file_path = @file_handler.file_hashes[params[:id]]
+      @file_path = @file_handler.file_hashes[params[:hashed_file_path]]
       if @file_path.nil?
         flash.alert = "File not found"
         redirect_to moirai_translation_files_path, status: :not_found
-        return
       end
-      @decoded_path = CGI.unescape(@file_path)
     end
 
     def translation_params

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -16,6 +16,7 @@ module Moirai
     def show
       @translation_keys = @file_handler.parse_file(@decoded_path)
       @locale = @file_handler.get_first_key(@decoded_path)
+      @translations = Moirai::Translation.find_by_file_path(@decoded_path)
     end
 
     def create_or_update

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -54,6 +54,11 @@ module Moirai
     end
 
     def handle_create
+      if translation_params[:value].blank?
+        flash.alert = "Translation value can't be blank."
+        return
+      end
+
       file_path = KeyFinder.new.file_path_for(translation_params[:key], locale: translation_params[:locale])
 
       if translation_same_as_in_file?

--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -40,7 +40,7 @@ module Moirai
       if translation_params[:value].blank? || translation_same_as_in_file?
         translation.destroy
         flash.notice = "Translation #{translation.key} was successfully deleted."
-        redirect_to_translation_file(translation.find_file_path)
+        redirect_to_translation_file(translation.file_path)
         return
       end
 
@@ -80,7 +80,7 @@ module Moirai
           render json: {}
         end
         format.all do
-          redirect_to_translation_file(translation.find_file_path)
+          redirect_to_translation_file(translation.file_path)
         end
       end
     end

--- a/app/models/moirai/key_finder.rb
+++ b/app/models/moirai/key_finder.rb
@@ -13,6 +13,7 @@ module Moirai
 
     # TODO: remove locale default
     def file_path_for(key, locale: I18n.locale)
+      locale ||= I18n.locale
       moirai_translations[locale.to_sym][key]
     end
 

--- a/app/models/moirai/key_finder.rb
+++ b/app/models/moirai/key_finder.rb
@@ -11,6 +11,7 @@ module Moirai
       load_translations
     end
 
+    # TODO: remove locale default
     def file_path_for(key, locale: I18n.locale)
       moirai_translations[locale.to_sym][key]
     end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -2,7 +2,7 @@
 
 module Moirai
   class Translation < Moirai::ApplicationRecord
-    validates_presence_of :key, :locale
+    validates_presence_of :key, :locale, :value
 
     def file_path
       @key_finder ||= KeyFinder.new

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -10,9 +10,7 @@ module Moirai
     end
 
     def self.by_file_path(file_path)
-      pp file_path
       key_finder = KeyFinder.new
-      pp key_finder.moirai_translations
       all.select { |translation| key_finder.file_path_for(translation.key, locale: translation.locale) == file_path }
     end
   end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -3,5 +3,17 @@
 module Moirai
   class Translation < Moirai::ApplicationRecord
     validates_presence_of :key, :locale
+
+    def find_file_path
+      @key_finder = KeyFinder.new
+      @key_finder.file_path_for(key, locale: locale)
+    end
+
+    def self.by_file_path(file_path)
+      pp file_path
+      key_finder = KeyFinder.new
+      pp key_finder.moirai_translations
+      all.select { |translation| key_finder.file_path_for(translation.key, locale: translation.locale) == file_path }
+    end
   end
 end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -4,7 +4,7 @@ module Moirai
   class Translation < Moirai::ApplicationRecord
     validates_presence_of :key, :locale
 
-    def find_file_path
+    def file_path
       @key_finder ||= KeyFinder.new
       @key_finder.file_path_for(key, locale: locale)
     end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -5,7 +5,7 @@ module Moirai
     validates_presence_of :key, :locale
 
     def find_file_path
-      @key_finder = KeyFinder.new
+      @key_finder ||= KeyFinder.new
       @key_finder.file_path_for(key, locale: locale)
     end
 

--- a/app/views/moirai/translation_files/_form.html.erb
+++ b/app/views/moirai/translation_files/_form.html.erb
@@ -3,7 +3,6 @@
   data-action="blur->moirai-translation#submit click->moirai-translation#click" 
   style="border: 1px dashed #1d9f74; min-width: 30px; display: inline-block;" 
   data-key="<%= key %>" 
-  data-file-path="<%= file_path %>" 
   data-controller="moirai-translation">
   <%= value %>
 </span>

--- a/app/views/moirai/translation_files/_form.html.erb
+++ b/app/views/moirai/translation_files/_form.html.erb
@@ -3,6 +3,7 @@
   data-action="blur->moirai-translation#submit click->moirai-translation#click" 
   style="border: 1px dashed #1d9f74; min-width: 30px; display: inline-block;" 
   data-key="<%= key %>" 
+  data-locale="<%= locale %>"
   data-controller="moirai-translation">
   <%= value %>
 </span>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -24,7 +24,7 @@
             <% end %>
           </td>
           <td>
-            <%= form_for translation&.presence || Moirai::Translation.new, url: moirai_create_or_update_translation_path do |f| %>
+            <%= form_for translation&.presence || Moirai::Translation.new, url: moirai_create_or_update_translation_path, method: :post do |f| %>
               <%= f.hidden_field :key, value: key %>
               <%= f.hidden_field :locale, value: @locale %>
               <%= f.text_field :value, value: translation&.value || value %>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -25,7 +25,7 @@
             <% end %>
           </td>
           <td>
-            <%= form_for translation.presence? || Moirai::Translation.new, url: moirai_create_or_update_translation_path do |f| %>
+            <%= form_for translation&.presence || Moirai::Translation.new, url: moirai_create_or_update_translation_path do |f| %>
               <%= f.hidden_field :key, value: key %>
               <%= f.hidden_field :locale, value: @locale %>
               <%= f.text_field :value, value: translation&.value || value %>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -12,8 +12,9 @@
       </tr>
     </thead>
     <tbody>
+      <% translations = Moirai::Translation.find_by_file_path(@decoded_path) %>
       <% @translation_keys.each do |key, value| %>
-        <% translation = Moirai::Translation.find_by(key: key, file_path: @decoded_path) %>
+        <% translation = translations.find { |t| t.key == key } %>
 
         <tr>
           <td>
@@ -27,6 +28,7 @@
             <%= form_for Moirai::Translation.new, url: moirai_create_or_update_translation_path do |f| %>
               <%= f.hidden_field :key, value: key %>
               <%= f.hidden_field :file_path, value: @decoded_path %>
+              <%= f.hidden_field :locale, value: @locale %>
               <%= f.text_field :value, value: translation&.value || value %>
               <%= f.submit 'Update', style: 'display: none;' %>
             <% end %>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -14,7 +14,7 @@
     <tbody>
       <% translations = Moirai::Translation.find_by_file_path(@decoded_path) %>
       <% @translation_keys.each do |key, value| %>
-        <% translation = translations.find { |t| t.key == key } %>
+        <% translation = @translations.find { |t| t.key == key } %>
 
         <tr>
           <td>
@@ -25,9 +25,8 @@
             <% end %>
           </td>
           <td>
-            <%= form_for Moirai::Translation.new, url: moirai_create_or_update_translation_path do |f| %>
+            <%= form_for translation.presence? || Moirai::Translation.new, url: moirai_create_or_update_translation_path do |f| %>
               <%= f.hidden_field :key, value: key %>
-              <%= f.hidden_field :file_path, value: @decoded_path %>
               <%= f.hidden_field :locale, value: @locale %>
               <%= f.text_field :value, value: translation&.value || value %>
               <%= f.submit 'Update', style: 'display: none;' %>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -24,10 +24,10 @@
             <% end %>
           </td>
           <td>
-            <%= form_for translation&.presence || Moirai::Translation.new, url: moirai_create_or_update_translation_path, method: :post do |f| %>
-              <%= f.hidden_field :key, value: key %>
-              <%= f.hidden_field :locale, value: @locale %>
-              <%= f.text_field :value, value: translation&.value || value %>
+            <%= form_for translation&.presence || Moirai::Translation.new(key: key, locale: @locale, value: value), url: moirai_create_or_update_translation_path, method: :post do |f| %>
+              <%= f.hidden_field :key %>
+              <%= f.hidden_field :locale %>
+              <%= f.text_field :value %>
               <%= f.submit 'Update', style: 'display: none;' %>
             <% end %>
           </td>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -12,7 +12,6 @@
       </tr>
     </thead>
     <tbody>
-      <% translations = Moirai::Translation.find_by_file_path(@decoded_path) %>
       <% @translation_keys.each do |key, value| %>
         <% translation = @translations.find { |t| t.key == key } %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Moirai::Engine.routes.draw do
   root to: "translation_files#index"
 
-  resources :translation_files, only: %i[index show], as: "moirai_translation_files"
+  resources :translation_files, only: %i[index show], as: "moirai_translation_files", param: :hashed_file_path
   post "/translation_files/open_pr", to: "translation_files#open_pr", as: "moirai_open_pr"
   post "/translation_files", to: "translation_files#create_or_update", as: "moirai_create_or_update_translation"
 end

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -31,6 +31,7 @@ module Moirai
               if file_path.present?
                 render(partial: "moirai/translation_files/form",
                   locals: {key: scope_key_by_partial(key),
+                           locale: I18n.locale,
                            value: value})
               else
                 value

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -31,7 +31,6 @@ module Moirai
               if file_path.present?
                 render(partial: "moirai/translation_files/form",
                   locals: {key: scope_key_by_partial(key),
-                           file_path: file_path,
                            value: value})
               else
                 value

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -1,22 +1,23 @@
 require "test_helper"
 
-class TranslationFilesController < ActionDispatch::IntegrationTest
+class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @translation = Moirai::Translation.create(key: "locales.german", locale: "de", value: "Neudeutsch")
   end
 
-  test "#index" do
+  # Index action tests
+  test "index displays translation files" do
     get "/moirai"
 
     assert_response :success
-
     assert_select "h1", "Translation files"
     assert_includes response.body, "de.yml"
     assert_includes response.body, "en.yml"
     assert_includes response.body, "it.yml"
   end
 
-  test "#show exists" do
+  # Show action tests
+  test "show existing translation file" do
     get translation_file_url("config/locales/en.yml")
     assert_response :success
 
@@ -24,12 +25,13 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_select "code", "./config/locales/en.yml"
   end
 
-  test "#show does not exist" do
+  test "show non-existing translation file" do
     get "/moirai/translation_files/does_not_exist"
     assert_response :not_found
   end
 
-  test "create with valid params" do
+  # Create action tests
+  test "create translation with valid params" do
     translation_count_before = Moirai::Translation.count
     post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "New Translation"}}
 
@@ -41,7 +43,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal translation_count_before + 1, Moirai::Translation.count
   end
 
-  test "create with same value" do
+  test "create translation with existing value" do
     translation_count_before = Moirai::Translation.count
 
     post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "German"}}
@@ -52,7 +54,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal translation_count_before, Moirai::Translation.count
   end
 
-  test "create with invalid params" do
+  test "create translation with invalid params" do
     translation_count_before = Moirai::Translation.count
 
     post "/moirai/translation_files", params: {translation: {key: "", locale: "", value: ""}}
@@ -62,7 +64,8 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal translation_count_before, Moirai::Translation.count
   end
 
-  test "update with blank value" do
+  # Update action tests
+  test "update translation with blank value" do
     count_before = Moirai::Translation.count
     post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: ""}}
 
@@ -72,7 +75,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal count_before - 1, Moirai::Translation.count
   end
 
-  test "update with non blank new value" do
+  test "update translation with non-blank new value" do
     post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: "Hochdeutsch"}}
 
     assert_response :redirect
@@ -82,7 +85,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal Moirai::Translation.last.value, "Hochdeutsch"
   end
 
-  test "update with value from file" do
+  test "update translation with value from file" do
     count_before = Moirai::Translation.count
     post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: "Deutsch"}}
 
@@ -91,11 +94,11 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal "Translation locales.german was successfully deleted.", flash[:notice]
     assert_equal count_before - 1, Moirai::Translation.count
   end
-end
 
-private
+  private
 
-def translation_file_url(local_path)
-  absolute_path = Rails.root.join(local_path).to_s
-  "/moirai/translation_files/#{Digest::SHA256.hexdigest(absolute_path)}"
+  def translation_file_url(local_path)
+    absolute_path = Rails.root.join(local_path).to_s
+    "/moirai/translation_files/#{Digest::SHA256.hexdigest(absolute_path)}"
+  end
 end

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -5,7 +5,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     @translation = Moirai::Translation.create(key: "test_key", locale: "en", value: "test_value")
   end
 
-  test "should get index" do
+  test "#index" do
     get "/moirai"
 
     assert_response :success
@@ -14,5 +14,18 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_includes response.body, "de.yml"
     assert_includes response.body, "en.yml"
     assert_includes response.body, "it.yml"
+  end
+
+  test "#show exists" do
+    get "/moirai/translation_files/#{Digest::SHA256.hexdigest(Rails.root.join("config/locales/en.yml").to_s)}"
+    assert_response :success
+
+    assert_select "h1", "Update translations"
+    assert_select "code", "./config/locales/en.yml"
+  end
+
+  test "#show does not exist" do
+    get "/moirai/translation_files/does_not_exist"
+    assert_response :not_found
   end
 end

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class TranslationFilesController < ActionDispatch::IntegrationTest
   setup do
-    @translation = Moirai::Translation.create(key: "test_key", locale: "en", value: "test_value")
+    @translation = Moirai::Translation.create(key: "locales.german", locale: "de", value: "Neudeutsch")
   end
 
   test "#index" do
@@ -37,7 +37,28 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/en.yml")
     assert_equal "Translation locales.german was successfully created.", flash[:notice]
-    assert_equal translation_count_before + 1, Moirai::Translation.count
+    assert_equal Moirai::Translation.last.key, "locales.german"
+    assert_equal Moirai::Translation.last.value, "New Translation"
+  end
+
+  test "#create_or_update with existing translation record" do
+    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "Hochdeutsch" } }
+
+    assert_response :redirect
+    assert_redirected_to translation_file_url("config/locales/de.yml")
+    assert_equal "Translation locales.german was successfully updated.", flash[:notice]
+    assert_equal Moirai::Translation.last.key, "locales.german"
+    assert_equal Moirai::Translation.last.value, "Hochdeutsch"
+  end
+
+  test "#create_or_update for existing translation with empty translation value restores translation from file" do
+    count_before = Moirai::Translation.count
+    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "" } }
+
+    assert_response :redirect
+    assert_redirected_to translation_file_url("config/locales/de.yml")
+    assert_equal "Translation locales.german was successfully deleted.", flash[:notice]
+    assert_equal count_before - 1, Moirai::Translation.count
   end
 end
 

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -29,8 +29,6 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  # create tests
-
   test "create with valid params" do
     translation_count_before = Moirai::Translation.count
     post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "New Translation"}}
@@ -63,8 +61,6 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal "Key can't be blank, Locale can't be blank", flash[:alert]
     assert_equal translation_count_before, Moirai::Translation.count
   end
-
-  # update tests
 
   test "update with blank value" do
     count_before = Moirai::Translation.count

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -33,19 +33,20 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
 
   test "create with valid params" do
     translation_count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "en", value: "New Translation" } }
+    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "New Translation"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/en.yml")
     assert_equal "Translation locales.german was successfully created.", flash[:notice]
     assert_equal Moirai::Translation.last.key, "locales.german"
     assert_equal Moirai::Translation.last.value, "New Translation"
+    assert_equal translation_count_before + 1, Moirai::Translation.count
   end
 
   test "create with same value" do
     translation_count_before = Moirai::Translation.count
 
-    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "en", value: "German" } }
+    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "German"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/en.yml")
@@ -56,7 +57,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
   test "create with invalid params" do
     translation_count_before = Moirai::Translation.count
 
-    post "/moirai/translation_files", params: { translation: { key: "", locale: "", value: "" } }
+    post "/moirai/translation_files", params: {translation: {key: "", locale: "", value: ""}}
 
     assert_response :unprocessable_entity
     assert_equal "Key can't be blank, Locale can't be blank", flash[:alert]
@@ -67,7 +68,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
 
   test "update with blank value" do
     count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "" } }
+    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: ""}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")
@@ -76,7 +77,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
   end
 
   test "update with non blank new value" do
-    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "Hochdeutsch" } }
+    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: "Hochdeutsch"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")
@@ -87,7 +88,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
 
   test "update with value from file" do
     count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "Deutsch" } }
+    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: "Deutsch"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -17,7 +17,7 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
   end
 
   test "#show exists" do
-    get "/moirai/translation_files/#{Digest::SHA256.hexdigest(Rails.root.join("config/locales/en.yml").to_s)}"
+    get translation_file_url("config/locales/en.yml")
     assert_response :success
 
     assert_select "h1", "Update translations"
@@ -28,4 +28,15 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     get "/moirai/translation_files/does_not_exist"
     assert_response :not_found
   end
+
+  test "#create_or_update with new translation" do
+    post "#{translation_file_url("config/locales/de.yml")}/translations", params: { translation: { key: "new_key", locale: "en", value: "new_value" } }
+  end
+end
+
+private
+
+def translation_file_url(local_path)
+  absolute_path = Rails.root.join(local_path).to_s
+  "/moirai/translation_files/#{Digest::SHA256.hexdigest(absolute_path)}"
 end

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -65,7 +65,17 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
 
   # update tests
 
-  test "#create_or_update with existing translation record" do
+  test "update with blank value" do
+    count_before = Moirai::Translation.count
+    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "" } }
+
+    assert_response :redirect
+    assert_redirected_to translation_file_url("config/locales/de.yml")
+    assert_equal "Translation locales.german was successfully deleted.", flash[:notice]
+    assert_equal count_before - 1, Moirai::Translation.count
+  end
+
+  test "update with non blank new value" do
     post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "Hochdeutsch" } }
 
     assert_response :redirect
@@ -75,9 +85,9 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal Moirai::Translation.last.value, "Hochdeutsch"
   end
 
-  test "#create_or_update for existing translation with empty translation value restores translation from file" do
+  test "update with value from file" do
     count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "" } }
+    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "Deutsch" } }
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -60,7 +60,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
     post translation_files_url, params: {translation: {key: "", locale: "", value: ""}}
 
     assert_response :unprocessable_entity
-    assert_equal "Key can't be blank, Locale can't be blank", flash[:alert]
+    assert_equal "Key can't be blank, Locale can't be blank, Value can't be blank", flash[:alert]
     assert_equal translation_count_before, Moirai::Translation.count
   end
 

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -29,8 +29,9 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  # existing file with existing translation, with no change record present
-  test "#create_or_update with new translation record" do
+  # create tests
+
+  test "create with valid params" do
     translation_count_before = Moirai::Translation.count
     post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "en", value: "New Translation" } }
 
@@ -40,6 +41,29 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_equal Moirai::Translation.last.key, "locales.german"
     assert_equal Moirai::Translation.last.value, "New Translation"
   end
+
+  test "create with same value" do
+    translation_count_before = Moirai::Translation.count
+
+    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "en", value: "German" } }
+
+    assert_response :redirect
+    assert_redirected_to translation_file_url("config/locales/en.yml")
+    assert_equal "Translation locales.german already exists.", flash[:alert]
+    assert_equal translation_count_before, Moirai::Translation.count
+  end
+
+  test "create with invalid params" do
+    translation_count_before = Moirai::Translation.count
+
+    post "/moirai/translation_files", params: { translation: { key: "", locale: "", value: "" } }
+
+    assert_response :unprocessable_entity
+    assert_equal "Key can't be blank, Locale can't be blank", flash[:alert]
+    assert_equal translation_count_before, Moirai::Translation.count
+  end
+
+  # update tests
 
   test "#create_or_update with existing translation record" do
     post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "de", value: "Hochdeutsch" } }

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class TranslationFilesController < ActionDispatch::IntegrationTest
+  setup do
+    @translation = Moirai::Translation.create(key: "test_key", locale: "en", value: "test_value")
+  end
+
+  test "should get index" do
+    get "/moirai"
+
+    assert_response :success
+
+    assert_select "h1", "Translation files"
+    assert_includes response.body, "de.yml"
+    assert_includes response.body, "en.yml"
+    assert_includes response.body, "it.yml"
+  end
+end

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -7,7 +7,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
 
   # Index action tests
   test "index displays translation files" do
-    get "/moirai"
+    get index_url
 
     assert_response :success
     assert_select "h1", "Translation files"
@@ -26,14 +26,14 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show non-existing translation file" do
-    get "/moirai/translation_files/does_not_exist"
+    get translation_file_url("does_not_exist.yml")
     assert_response :not_found
   end
 
   # Create action tests
   test "create translation with valid params" do
     translation_count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "New Translation"}}
+    post translation_files_url, params: {translation: {key: "locales.german", locale: "en", value: "New Translation"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/en.yml")
@@ -46,7 +46,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   test "create translation with existing value" do
     translation_count_before = Moirai::Translation.count
 
-    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "en", value: "German"}}
+    post translation_files_url, params: {translation: {key: "locales.german", locale: "en", value: "German"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/en.yml")
@@ -57,7 +57,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   test "create translation with invalid params" do
     translation_count_before = Moirai::Translation.count
 
-    post "/moirai/translation_files", params: {translation: {key: "", locale: "", value: ""}}
+    post translation_files_url, params: {translation: {key: "", locale: "", value: ""}}
 
     assert_response :unprocessable_entity
     assert_equal "Key can't be blank, Locale can't be blank", flash[:alert]
@@ -67,7 +67,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   # Update action tests
   test "update translation with blank value" do
     count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: ""}}
+    post translation_files_url, params: {translation: {key: "locales.german", locale: "de", value: ""}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")
@@ -76,7 +76,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update translation with non-blank new value" do
-    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: "Hochdeutsch"}}
+    post translation_files_url, params: {translation: {key: "locales.german", locale: "de", value: "Hochdeutsch"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")
@@ -87,7 +87,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
 
   test "update translation with value from file" do
     count_before = Moirai::Translation.count
-    post "/moirai/translation_files", params: {translation: {key: "locales.german", locale: "de", value: "Deutsch"}}
+    post translation_files_url, params: {translation: {key: "locales.german", locale: "de", value: "Deutsch"}}
 
     assert_response :redirect
     assert_redirected_to translation_file_url("config/locales/de.yml")
@@ -96,6 +96,14 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def index_url
+    "/moirai"
+  end
+
+  def translation_files_url
+    "/moirai/translation_files"
+  end
 
   def translation_file_url(local_path)
     absolute_path = Rails.root.join(local_path).to_s

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -29,8 +29,15 @@ class TranslationFilesController < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "#create_or_update with new translation" do
-    post "#{translation_file_url("config/locales/de.yml")}/translations", params: { translation: { key: "new_key", locale: "en", value: "new_value" } }
+  # existing file with existing translation, with no change record present
+  test "#create_or_update with new translation record" do
+    translation_count_before = Moirai::Translation.count
+    post "/moirai/translation_files", params: { translation: { key: "locales.german", locale: "en", value: "New Translation" } }
+
+    assert_response :redirect
+    assert_redirected_to translation_file_url("config/locales/en.yml")
+    assert_equal "Translation locales.german was successfully created.", flash[:notice]
+    assert_equal translation_count_before + 1, Moirai::Translation.count
   end
 end
 

--- a/test/models/moirai/translation_test.rb
+++ b/test/models/moirai/translation_test.rb
@@ -7,6 +7,15 @@ module Moirai
       @invalid_translation = Translation.new(key: "hello", locale: "en", file_path: "/invalid/path/to/file")
     end
 
+    test ".by_file_path" do
+      translation1 = Translation.create!(key: "locales.german", value: "Italian", locale: "en")
+      translation2 = Translation.create!(key: "locales.italian", value: "Italian", locale: "en")
+      translation3 = Translation.create!(key: "locales.german", value: "Italian", locale: "de")
+
+      assert_equal [translation1, translation2], Translation.by_file_path(Rails.root.join("config/locales/en.yml").to_s)
+      assert_equal [translation3], Translation.by_file_path(Rails.root.join("config/locales/de.yml").to_s)
+    end
+
     test "should be valid with valid attributes" do
       File.stub :exist?, true do
         assert @valid_translation.valid?

--- a/test/models/moirai/translation_test.rb
+++ b/test/models/moirai/translation_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 module Moirai
   class TranslationTest < ActiveSupport::TestCase
     def setup
-      @valid_translation = Translation.new(key: "hello", locale: "en", file_path: "/valid/path/to/file")
-      @invalid_translation = Translation.new(key: "hello", locale: "en", file_path: "/invalid/path/to/file")
+      @valid_translation = Translation.new(key: "hello", locale: "en", value: "Hello")
     end
 
     test ".by_file_path" do
@@ -32,6 +31,12 @@ module Moirai
       @valid_translation.locale = nil
       assert_not @valid_translation.valid?
       assert_includes @valid_translation.errors[:locale], "can't be blank"
+    end
+
+    test "should be invalid without value" do
+      @valid_translation.value = nil
+      assert_not @valid_translation.valid?
+      assert_includes @valid_translation.errors[:value], "can't be blank"
     end
   end
 end


### PR DESCRIPTION
[TICKET-22914](https://redmine.renuo.ch/issues/22914)

This PR builds on top of #32 and #38 with the goal of deprecating the `file_path` and adding support for gem translations and missing locales. 

Also added a bunch of controller tests.