### PR TITLE
Add support for strings in gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Support for strings coming from gems ([@coorasse][])
+* Support for new strings (not yet translated) ([@coorasse][])
+
 ## 0.1.1
 
 * Review Stimulus controller ([@coorasse][])

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ See the image below as an example:
 * Support for interpolation
 * Support for count variants
 * Better inline editing tool
-* Support for fallbacks: it should identify that a fallback string is being used on not try to override the value.
+* Support for fallbacks: it should detect when a fallback string is in use and prevent attempts to override its value.
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -188,8 +188,7 @@ See the image below as an example:
 * Support for interpolation
 * Support for count variants
 * Better inline editing tool
-* Performance of translations lookup
-* Support for translations and strings coming from other gems
+* Support for fallbacks: it should identify that a fallback string is being used on not try to override the value.
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/assets/javascripts/moirai_translation_controller.js
+++ b/app/assets/javascripts/moirai_translation_controller.js
@@ -23,7 +23,7 @@ export default class MoiraiTranslationController extends Controller {
       body: JSON.stringify({
         translation: {
           key: this.keyValue,
-          locale: this.localeValue
+          locale: this.localeValue,
           value: event.target.innerText
         }
       })

--- a/app/controllers/moirai/translations_controller.rb
+++ b/app/controllers/moirai/translations_controller.rb
@@ -1,0 +1,7 @@
+module Moirai
+  class TranslationsController < ApplicationController
+    def index
+      @translations = Translation.order(created_at: :desc).pluck(:locale, :key, :value)
+    end
+  end
+end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -4,14 +4,15 @@ module Moirai
   class Translation < Moirai::ApplicationRecord
     validates_presence_of :key, :locale, :value
 
+    # what if the key is present in multiple file_paths?
     def file_path
       @key_finder ||= KeyFinder.new
-      @key_finder.file_path_for(key, locale: locale)
+      @key_finder.file_paths_for(key, locale: locale).first
     end
 
     def self.by_file_path(file_path)
       key_finder = KeyFinder.new
-      all.select { |translation| key_finder.file_path_for(translation.key, locale: translation.locale) == file_path }
+      all.select { |translation| key_finder.file_paths_for(translation.key, locale: translation.locale).include?(file_path) }
     end
   end
 end

--- a/app/views/moirai/translation_files/_form.html.erb
+++ b/app/views/moirai/translation_files/_form.html.erb
@@ -1,9 +1,9 @@
 <span 
   contenteditable 
-  data-action="blur->moirai-translation#submit click->moirai-translation#click" 
+  data-action="blur->moirai-translation#submit click->moirai-translation#click"
   style="border: 1px dashed #1d9f74; min-width: 30px; display: inline-block;" 
-  data-key="<%= key %>" 
-  data-locale="<%= locale %>"
+  data-moirai-translation-key-value="<%= key %>"
+  data-moirai-translation-locale-value="<%= locale %>"
   data-controller="moirai-translation">
   <%= value %>
 </span>

--- a/app/views/moirai/translation_files/index.html.erb
+++ b/app/views/moirai/translation_files/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Translation files</h1>
 
 <% if Moirai::PullRequestCreator.available? %>
-  <%= button_to "Create or update PR", moirai_open_pr_path %>
+  <%= button_to "Create or update Pull Request", moirai_open_pr_path %>
 <% else %>
   <p>PR creation is not available. Add the gem octokit to your gemfile to enable this feature</p>
 <% end %>

--- a/app/views/moirai/translations/index.html.erb
+++ b/app/views/moirai/translations/index.html.erb
@@ -1,0 +1,7 @@
+<% @translations.each do |locale, key, value| %>
+  <div class="card">
+    <p><strong>Locale:</strong> <%=locale %></p>
+    <p><strong>Key:</strong> <%=key %></p>
+    <p><strong>Value:</strong> <%= value %></p>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Moirai::Engine.routes.draw do
   root to: "translation_files#index"
 
+  resources :translations, only: %i[index]
   resources :translation_files, only: %i[index show], as: "moirai_translation_files", param: :hashed_file_path
   post "/translation_files/open_pr", to: "translation_files#open_pr", as: "moirai_open_pr"
   post "/translation_files", to: "translation_files#create_or_update", as: "moirai_create_or_update_translation"

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -9,9 +9,7 @@ module Moirai
     end
 
     config.after_initialize do
-      moirai_backend = I18n::Backend::Moirai.new
-      moirai_backend.eager_load!
-      I18n.backend = I18n::Backend::Chain.new(moirai_backend, I18n.backend)
+      I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Moirai.new, I18n.backend)
     end
 
     # TODO: how to do this without rewriting the entire method?
@@ -26,16 +24,11 @@ module Moirai
 
             if moirai_edit_enabled?
               @key_finder ||= Moirai::KeyFinder.new
-              file_path = @key_finder.file_path_for(scope_key_by_partial(key), locale: I18n.locale)
 
-              if file_path.present?
-                render(partial: "moirai/translation_files/form",
-                  locals: {key: scope_key_by_partial(key),
-                           locale: I18n.locale,
-                           value: value})
-              else
-                value
-              end
+              render(partial: "moirai/translation_files/form",
+                locals: {key: scope_key_by_partial(key),
+                         locale: I18n.locale,
+                         value: value})
             else
               value
             end

--- a/test/controllers/moirai/translation_files_controller_test.rb
+++ b/test/controllers/moirai/translation_files_controller_test.rb
@@ -48,8 +48,7 @@ class TranslationFilesControllerTest < ActionDispatch::IntegrationTest
 
     post translation_files_url, params: {translation: {key: "locales.german", locale: "en", value: "German"}}
 
-    assert_response :redirect
-    assert_redirected_to translation_file_url("config/locales/en.yml")
+    assert_response :unprocessable_entity
     assert_equal "Translation locales.german already exists.", flash[:alert]
     assert_equal translation_count_before, Moirai::Translation.count
   end

--- a/test/dummy/app/views/home/index.html.erb
+++ b/test/dummy/app/views/home/index.html.erb
@@ -10,3 +10,12 @@
 <button><%= t('buttons.very.much.nested.only_english') %></button>
 <button><%= t('buttons.very.much.nested.only_italian') %></button>
 
+<p>
+  'date.formats.short' => <%= t('date.formats.short') %>
+</p>
+<p>
+  'date.formats.default' => <%= t('date.formats.default') %>
+</p>
+<p>
+  'time.formats.default' => <%= t('time.formats.default') %>
+</p>

--- a/test/dummy/config/locales/another.de.yml
+++ b/test/dummy/config/locales/another.de.yml
@@ -1,0 +1,4 @@
+de:
+  enumerations:
+    countries:
+      ch: Schweiz

--- a/test/dummy/config/locales/rails.en.yml
+++ b/test/dummy/config/locales/rails.en.yml
@@ -1,0 +1,4 @@
+en:
+  date:
+    formats:
+      short: "%Y"

--- a/test/models/moirai/key_finder_test.rb
+++ b/test/models/moirai/key_finder_test.rb
@@ -4,12 +4,39 @@ require "test_helper"
 
 module Moirai
   class KeyFinderTest < ActiveSupport::TestCase
+    def setup
+      @key_finder = KeyFinder.new
+    end
     test "it finds the file path of a given key" do
-      key_finder = KeyFinder.new
-      assert_match(%r{config/locales/de.yml}, key_finder.file_path_for("locales.italian", locale: :de))
-      assert_match(%r{config/locales/de.yml}, key_finder.file_path_for("locales.italian", locale: "de"))
-      assert_match(%r{config/locales/it.yml}, key_finder.file_path_for("locales.italian", locale: :it))
-      assert_nil key_finder.file_path_for("missing.key")
+      assert_match %r{config/locales/de.yml}, @key_finder.file_paths_for("locales.italian", locale: :de).first
+      assert_match %r{config/locales/de.yml}, @key_finder.file_paths_for("locales.italian", locale: "de").first
+      assert_match %r{config/locales/it.yml}, @key_finder.file_paths_for("locales.italian", locale: :it).first
+      assert_match %r{config/locales/another.de.yml},
+        @key_finder.file_paths_for("enumerations.countries.ch", locale: :de).first
+    end
+
+    test "it finds parent keys" do
+      assert_match %r{config/locales/en.yml}, @key_finder.file_paths_for("buttons.very.much", locale: :en).first
+    end
+
+    test "it returns an empty array for an empty key" do
+      assert_empty @key_finder.file_paths_for("", locale: :en)
+    end
+
+    test "it finds keys in gems" do
+      assert_match %r{active_support/locale/en.yml}, @key_finder.file_paths_for("date.month_names", locale: :en).first
+    end
+
+    test "it returns local files before gem files" do
+      file_paths = @key_finder.file_paths_for("date.formats.short", locale: :en)
+      assert_match %r{config/locales/rails.en.yml}, file_paths.first
+      assert_match %r{active_support/locale/en.yml}, file_paths.second
+    end
+
+    test "it returns nil if there is not match" do
+      assert_empty @key_finder.file_paths_for("missing.key")
+      assert_empty @key_finder.file_paths_for("buttons.very.much.nested.only_german", locale: :en)
+      assert @key_finder.file_paths_for("buttons.very.much.nested", locale: :en)
     end
   end
 end

--- a/test/system/happy_path_test.rb
+++ b/test/system/happy_path_test.rb
@@ -26,25 +26,22 @@ class HappyPathTest < ApplicationSystemTestCase
   def test_inline_editors
     visit "/?moirai=true"
     assert_key_editable page, "buttons.very.much.nested.only_english"
-    refute_key_editable page, "buttons.very.much.nested.only_italian"
-    refute_key_editable page, "buttons.very.much.nested.only_german"
+    assert_key_editable page, "buttons.very.much.nested.only_italian"
+    assert_key_editable page, "buttons.very.much.nested.only_german"
 
     visit "/?locale=de&moirai=true"
-    refute_key_editable page, "buttons.very.much.nested.only_english"
-    refute_key_editable page, "buttons.very.much.nested.only_italian"
+    assert_key_editable page, "buttons.very.much.nested.only_english"
+    assert_key_editable page, "buttons.very.much.nested.only_italian"
     assert_key_editable page, "buttons.very.much.nested.only_german"
 
     visit "/?locale=it&moirai=true"
-    refute_key_editable page, "buttons.very.much.nested.only_english"
+    assert_key_editable page, "buttons.very.much.nested.only_english"
     assert_key_editable page, "buttons.very.much.nested.only_italian"
-    refute_key_editable page, "buttons.very.much.nested.only_german"
+    assert_key_editable page, "buttons.very.much.nested.only_german"
   end
 
   def assert_key_editable(page, key)
-    assert_selector page, "[data-controller=\"moirai-translation\"][data-key=\"#{key}\"]"
-  end
-
-  def refute_key_editable(page, key)
-    refute_selector page, "[data-controller=\"moirai-translation\"][data-key=\"#{key}\"]"
+    assert_selector page,
+      "[data-controller=\"moirai-translation\"][data-moirai-translation-key-value=\"#{key}\"]"
   end
 end


### PR DESCRIPTION
This PR adds support for both strings coming from gems and strings not yet translated in the current language.
It enables to widen much more the range of strings that is possible to translate with moirai.

Replaces #32 