### PR TITLE
Synchronize database and locale files on application boot (i.e. release)

### DIFF
--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -14,5 +14,18 @@ module Moirai
       key_finder = KeyFinder.new
       all.select { |translation| key_finder.file_paths_for(translation.key, locale: translation.locale).include?(file_path) }
     end
+
+    def in_sync_with_file?
+      file_translation = file_value
+      file_translation.present? && file_translation == value
+    end
+
+    def file_value
+      return nil unless file_path
+
+      file_handler = TranslationFileHandler.new
+      file_content = file_handler.parse_file(file_path)
+      file_content[key]
+    end
   end
 end

--- a/app/models/moirai/translation.rb
+++ b/app/models/moirai/translation.rb
@@ -16,16 +16,8 @@ module Moirai
     end
 
     def in_sync_with_file?
-      file_translation = file_value
-      file_translation.present? && file_translation == value
-    end
-
-    def file_value
-      return nil unless file_path
-
-      file_handler = TranslationFileHandler.new
-      file_content = file_handler.parse_file(file_path)
-      file_content[key]
+      translation_without_moirai = I18n.translate_without_moirai(key, locale)
+      translation_without_moirai.present? && translation_without_moirai == value
     end
   end
 end

--- a/app/models/moirai/translation_sync.rb
+++ b/app/models/moirai/translation_sync.rb
@@ -1,0 +1,36 @@
+module Moirai
+  class TranslationSync
+    def initialize
+      @translations = Moirai::Translation.all
+      @file_handler = TranslationFileHandler.new
+      @file_translations = load_locale_files
+    end
+
+    def synchronize
+      Rails.logger.info "Synchronizing translations..."
+      @translations.each do |translation|
+        translation.destroy if translation_in_sync?(translation)
+      end
+      Rails.logger.info "Synchronization complete."
+    end
+
+    private
+
+    def load_locale_files
+      @file_handler.file_paths.each_with_object({}) do |file_path, translations|
+        locale = @file_handler.get_first_key(file_path)
+        translation_keys = @file_handler.parse_file(file_path)
+        translations.merge!(namespaced_keys(translation_keys, locale))
+      end
+    end
+
+    def namespaced_keys(translation_keys, locale)
+      translation_keys.transform_keys { |key| "#{locale}.#{key}" }
+    end
+
+    def translation_in_sync?(translation)
+      file_translation = @file_translations["#{translation.locale}.#{translation.key}"]
+      file_translation.present? && file_translation == translation.value
+    end
+  end
+end

--- a/app/models/moirai/translation_sync.rb
+++ b/app/models/moirai/translation_sync.rb
@@ -2,35 +2,14 @@ module Moirai
   class TranslationSync
     def initialize
       @translations = Moirai::Translation.all
-      @file_handler = TranslationFileHandler.new
-      @file_translations = load_locale_files
     end
 
     def synchronize
       Rails.logger.info "Synchronizing translations..."
       @translations.each do |translation|
-        translation.destroy if translation_in_sync?(translation)
+        translation.destroy if translation.in_sync_with_file?
       end
       Rails.logger.info "Synchronization complete."
-    end
-
-    private
-
-    def load_locale_files
-      @file_handler.file_paths.each_with_object({}) do |file_path, translations|
-        locale = @file_handler.get_first_key(file_path)
-        translation_keys = @file_handler.parse_file(file_path)
-        translations.merge!(namespaced_keys(translation_keys, locale))
-      end
-    end
-
-    def namespaced_keys(translation_keys, locale)
-      translation_keys.transform_keys { |key| "#{locale}.#{key}" }
-    end
-
-    def translation_in_sync?(translation)
-      file_translation = @file_translations["#{translation.locale}.#{translation.key}"]
-      file_translation.present? && file_translation == translation.value
     end
   end
 end

--- a/lib/i18n/extensions/i18n.rb
+++ b/lib/i18n/extensions/i18n.rb
@@ -8,6 +8,10 @@ module I18n
   def self.translate_without_moirai(key, locale, **)
     raise "Original backend is not set" unless original_backend
 
-    original_backend.translate(locale, key, **)
+    begin
+      original_backend.translate(locale, key, **)
+    rescue
+      nil
+    end
   end
 end

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -19,6 +19,7 @@ module Moirai
         end
       if table_created
         I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Moirai.new, I18n.backend)
+        Moirai::TranslationSync.new.synchronize
       else
         Rails.logger.warn("moirai disabled: tables have not been generated yet.")
       end

--- a/test/dummy/config/locales/de.yml
+++ b/test/dummy/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   locales:
     german: Deutsch

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -6,6 +6,11 @@ require "moirai/translation_helper"
 class I18nExtensionsTest < ActiveSupport::TestCase
   include ActionView::Helpers::TranslationHelper
 
+  before do
+    Rails.cache.clear
+    I18n.reload!
+  end
+
   test "it correctly translates using .translate and .translate_without_moirai" do
     assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
 

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -6,12 +6,10 @@ require "moirai/translation_helper"
 class I18nExtensionsTest < ActiveSupport::TestCase
   include ActionView::Helpers::TranslationHelper
 
-  before do
+  test "it correctly translates using .translate and .translate_without_moirai" do
     Rails.cache.clear
     I18n.reload!
-  end
 
-  test "it correctly translates using .translate and .translate_without_moirai" do
     assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
 
     Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")

--- a/test/models/moirai/translation_test.rb
+++ b/test/models/moirai/translation_test.rb
@@ -4,6 +4,8 @@ module Moirai
   class TranslationTest < ActiveSupport::TestCase
     def setup
       @valid_translation = Translation.new(key: "hello", locale: "en", value: "Hello")
+      @translation_with_config = Translation.new(key: "locales.german", locale: "en", value: "German")
+      @out_of_sync_translation_with_config = Translation.new(key: "locales.german", locale: "en", value: "Italian")
     end
 
     test ".by_file_path" do
@@ -13,6 +15,16 @@ module Moirai
 
       assert_equal [translation1, translation2], Translation.by_file_path(Rails.root.join("config/locales/en.yml").to_s)
       assert_equal [translation3], Translation.by_file_path(Rails.root.join("config/locales/de.yml").to_s)
+    end
+
+    test ".file_value" do
+      assert_equal "German", @translation_with_config.file_value
+    end
+
+    test ".in_sync_with_file?" do
+      assert_equal true, @translation_with_config.in_sync_with_file?
+      assert_equal false, @valid_translation.in_sync_with_file?
+      assert_equal false, @out_of_sync_translation_with_config.in_sync_with_file?
     end
 
     test "should be valid with valid attributes" do

--- a/test/models/moirai/translation_test.rb
+++ b/test/models/moirai/translation_test.rb
@@ -4,8 +4,8 @@ module Moirai
   class TranslationTest < ActiveSupport::TestCase
     def setup
       @valid_translation = Translation.new(key: "hello", locale: "en", value: "Hello")
-      @translation_with_config = Translation.new(key: "locales.german", locale: "en", value: "German")
-      @out_of_sync_translation_with_config = Translation.new(key: "locales.german", locale: "en", value: "Italian")
+      @translation_in_sync = Translation.new(key: "locales.german", locale: "en", value: "German")
+      @translation_out_of_sync = Translation.new(key: "locales.german", locale: "en", value: "Italian")
     end
 
     test ".by_file_path" do
@@ -17,14 +17,10 @@ module Moirai
       assert_equal [translation3], Translation.by_file_path(Rails.root.join("config/locales/de.yml").to_s)
     end
 
-    test ".file_value" do
-      assert_equal "German", @translation_with_config.file_value
-    end
-
     test ".in_sync_with_file?" do
-      assert_equal true, @translation_with_config.in_sync_with_file?
       assert_equal false, @valid_translation.in_sync_with_file?
-      assert_equal false, @out_of_sync_translation_with_config.in_sync_with_file?
+      assert_equal true, @translation_in_sync.in_sync_with_file?
+      assert_equal false, @translation_out_of_sync.in_sync_with_file?
     end
 
     test "should be valid with valid attributes" do

--- a/test/services/translation_sync_test.rb
+++ b/test/services/translation_sync_test.rb
@@ -20,11 +20,6 @@ module Moirai
       
       assert_equal 1, Moirai::Translation.count
 
-      Rails.cache.clear
-      I18n.reload!
-
-      assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
-
       modified_de_yaml = {
         de: {
           locales: {

--- a/test/services/translation_sync_test.rb
+++ b/test/services/translation_sync_test.rb
@@ -17,7 +17,7 @@ module Moirai
       assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
 
       Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")
-      
+
       assert_equal 1, Moirai::Translation.count
 
       modified_de_yaml = {

--- a/test/services/translation_sync_test.rb
+++ b/test/services/translation_sync_test.rb
@@ -17,6 +17,11 @@ module Moirai
       assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
 
       Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")
+      
+      assert_equal 1, Moirai::Translation.count
+
+      Rails.cache.clear
+      I18n.reload!
 
       assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
 

--- a/test/services/translation_sync_test.rb
+++ b/test/services/translation_sync_test.rb
@@ -19,6 +19,7 @@ module Moirai
       Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")
 
       assert_equal 1, Moirai::Translation.count
+      assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
 
       modified_de_yaml = {
         de: {
@@ -28,6 +29,8 @@ module Moirai
         }
       }
       File.write(@de_file_path, modified_de_yaml.to_yaml)
+
+      I18n.reload!
 
       # initialize the service here so that we have the correct data
       @translation_sync_service = Moirai::TranslationSync.new

--- a/test/services/translation_sync_test.rb
+++ b/test/services/translation_sync_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Moirai
+  class TranslationSyncTest < ActiveSupport::TestCase
+    setup do
+      @de_file_path = Rails.root.join("config/locales/de.yml").to_s
+      @original_de_content = YAML.load_file(@de_file_path)
+    end
+
+    teardown do
+      File.write(@de_file_path, @original_de_content.to_yaml)
+    end
+
+    test "it synchronizes translations" do
+      assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
+
+      Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")
+
+      assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
+
+      modified_de_yaml = {
+        de: {
+          locales: {
+            italian: "Italianese"
+          }
+        }
+      }
+      File.write(@de_file_path, modified_de_yaml.to_yaml)
+
+      # initialize the service here so that we have the correct data
+      @translation_sync_service = Moirai::TranslationSync.new
+
+      assert_difference -> { Moirai::Translation.count }, -1 do
+        @translation_sync_service.synchronize
+      end
+    end
+
+    test "it retains records that do not match locale files" do
+      Moirai::Translation.create!(locale: "de", key: "locales.french", value: "Französisch")
+
+      # initialize the service here so that we have the correct data
+      @translation_sync_service = Moirai::TranslationSync.new
+
+      assert_no_difference -> { Moirai::Translation.count } do
+        @translation_sync_service.synchronize
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have confirmed that this occurs when the app is started: 
 
development logs:
```
[dotenv] Set [36mMOIRAI_GITHUB_REPO_NAME[0m and [36mGITHUB_ACCESS_TOKEN[0m
[dotenv] Loaded [33m.env[0m
[dotenv] Loaded [33m.env[0m
Synchronizing translations...
  [1m[36mMoirai::Translation Load (5.1ms)[0m  [1m[34mSELECT "moirai_translations".* FROM "moirai_translations"[0m
  ↳ config/environment.rb:7:in `<top (required)>'
Synchronization complete.
```

Closes #49