### PR TITLE
Discard flash messages in inline editing

### DIFF
--- a/app/controllers/moirai/translation_files_controller.rb
+++ b/app/controllers/moirai/translation_files_controller.rb
@@ -74,6 +74,7 @@ module Moirai
     def success_response(translation)
       respond_to do |format|
         format.json do
+          flash.discard
           render json: {}
         end
         format.all do


### PR DESCRIPTION
The flash message is not displayed anyway in the inline editing and if the user navigated away, was shown in the next page. Let's remove it and rethink the feedback 