### PR TITLE
Add translate_to_original method using original_backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          
-      - name: Run Moirai install generator
-        run: bin/rails g moirai:install
-      
-      - name: Run database migrations
-        run: bin/rails db:migrate RAILS_ENV=test
-
       
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
 
       - name: Run system tests
         run: bundle exec rails test:system
+
+      - name: Archive logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: test.log
+          path: test/dummy/log/test.log
   
   
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          
+      - name: Run Moirai install generator
+        run: bin/rails g moirai:install
+      
+      - name: Run database migrations
+        run: bin/rails db:migrate RAILS_ENV=test
+
       
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,11 @@ jobs:
         run: bundle exec rails test:system
 
       - name: Archive logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test.log
           path: test/dummy/log/test.log
-  
-  
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/app/assets/stylesheets/moirai/application.css
+++ b/app/assets/stylesheets/moirai/application.css
@@ -12,4 +12,6 @@
  *
  *= require_tree .
  *= require_self
+ *= require translation_files
+
  */

--- a/app/assets/stylesheets/translation_files.css
+++ b/app/assets/stylesheets/translation_files.css
@@ -1,0 +1,22 @@
+td {
+  height: 100px;
+  width: 200px;
+  vertical-align: top;
+}
+
+form {
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+}
+
+textarea.translation-textarea {
+  width: 100%;
+  height: auto;
+  resize: vertical;
+  min-height: 3em;
+  overflow: hidden;
+  margin-bottom: 0;
+}
+
+/*# TODO: this isn't coming through */

--- a/app/views/layouts/moirai/application.html.erb
+++ b/app/views/layouts/moirai/application.html.erb
@@ -8,6 +8,34 @@
   <%= stylesheet_link_tag    "moirai/application", media: "all" %>
   <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
   <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAC/VBMVEUAAACcnKyEcFGLlc/AuavOyr+tm3zCrIGTgmaDbkypnojJw6rQv5jNv6TX5fLl8v+fiGatmnPFtpKXgWKVgF2Tg2WVfFmhkG+ejG2kjmmrmXqiloGGb0urnH+pnonDupyNdVHSyamempOSe1q5sqSQioqkk2yThmuWeVONeVaPgmeIdFXItIvArYaMdlOSfVm3qIKxo3+unXijjmePgWeXhmmSfFrEs5C8rozQw5zUxqSelIC2o33Nw6Sgi2imlnuZi3SfiGewoYStn4eVhGquopWampXJw66VlZWqqp6He2aYj3q6rJKqo5GWj3+Nf2VmWUXAuaSlnYqhmoidl4aSineThW2OhG2CemiFdFh7ZUXJxbLFv6q5taSjno2wpIusoIaalYakmICik3qWjXqOhXOViG+Kgm5+dGCRfFqFb01lWklvXkXd2MTBuqa5sp20rZqwqpi8sJetp5S2qZCdmIm2p4ieloKqnIGak4GtnoCdlX+OiHeik3SYi3SKhHSRhnKdjnGciGWTgWSbhGCDd2CMfF5/c153cF56b1uBcVh1a1h+cFWHc1SPd1OKdFNxZ1N7a1J1aFJoYE9uYUt0Y0pxYkptX0diVkRbUEDX0LrIwau9uKi8t6PAs5WzqpSyqJCpoIy/rYWgl4WXk4OWkYOpmXySjXycknu4oXedkHe1nHGMgnGGf3CJf2yShGqkj2l9dmV4c2OWg2CTf1+HeF6CdV2Wf1yKeFqJeFd4a1WBb1GKck90Z0/V0cLOy7nPyLLLwqvKv6PCt568tJ6/s5q4sJinpZTMuZC9sI+uoYinnIWmlniBfW+gjmyPgmqEe2msk2iXhmiJe2SgiGKFeGCVgV9zbV6jiVxwalmQeVeDcVR5Z01qXEl+Z0VzXkBIPzHi38zExbnFw7TTyrLe0ajCvai0saHWxp7NvJqZl47UuYWim4XKsoSmmoC0oX6ym3aZjXSnlG+Wg2Ssj2J9cluYflKVeU90YkNtWz90Xj5mUjhXSThYSzdqUjbGwv6GAAAASnRSTlMACv4FHBL9+OaxWUU7KQwG6+Pg4NzW1sO1qZ2Zl5BtbGxYSTYkE/78/Pr4+PTw8O/t5djYy8rKxsG/sKunnZGBcG1qYFc8MC8pFazVjw8AAAMwSURBVDjLlZNTcFxhGEC32zRJU6S2bdvGXds2Ytu2bdtO6sa2k9o2p707yaTNtA85r+fM/Jjvg0yAydOOz9mmoqKy/eBKpX/p1YeV88t8AgZK3fvyZi9fN97POLJBPgBYi3S0SYQYwoeS2Wcm/+WnzZFYG6NE2sj7N7h+sJeRrUF5Syb96XfJnR5Ut1R04aOS+T2FKc/SPnflLx4rLu4OImdYZHcPhghQIlqGRVr3x0BnROeJUT/pkLvY6Ok9EvVnf44WDRnyzkuIsRJzXTedGwlWJhrGUhqqaJqBAYw7ScNyEh1jJCN1uHksWK/wU/a413tSOQ1WGrhMukZouABHCw7JbPLxrqCeVgSrS3KyqOj4CI1HV8KxJoxQDf5zgV4GzKvPHX1Acc9jgTpomdXdUDjnqjaTAcuJvglEmpGxXB9ft61rwRP2ypjBzXqaj1OQYUiGyDtOcLvJJtwPhsFZu6BWgX+40y3OKFcz9YWEqUMjA9W8dH0WhyFzQiBklpbLfgfToYAbBkF3bKcwr2g5w96S/JLpV8nEqDA/19q6qWDg4UTg02Ho1iCCZq6zGN0TEoSIH2bd8PY3vc1SBFAXbIxLMNvU1P9HbpW+A54AlX/7jg5GA0TdaDCYsUMcZ4SrNDS0saNgr9s0M7VcbYuk3kISm2fGXga+YgGQHoOtiW3kWQivsR3MDTCAXaOnb60+qjA6FXwFZHGBCcCKNTU2ViaawfjpBpjM/GxJQJ0uHA7fshYM1MqxKEv9J0JhohNCz8Tc4FabxL5TToQbwrn7FD+5fh5KzzdRubDYw/ohHofkVHZQ7Irs7QuM2VmnIApWSMw5PIpPe7YDPgJvkHBLXOzYW57mmPxm/uWReVhIRdRw7YpsgWs4HXxClEO/LdQzpcV/oxpkhAuzoFksooV9akTSdZN4s1KvvJLe959cl47N7ZpZX4k29a/bzLVuIhMIvmW2Umk55ehMUI0WcwcdC165aOvC+UmCUqkXdah4KejHuLTI80ugKEw3Eoa08h+SBqiuUB+/WWoLN5ehLHlksnOFh6pis8ajfv7kovnzVOfuX3JWCfI/ZiopTVGHTIhfmYNNrIltIWMAAAAASUVORK5CYII=">
+
+  <style>
+    td {
+      height: 100px; /* Ensure the cell has a consistent height */
+      width: 200px; /* Set a reasonable width */
+      vertical-align: top;
+    }
+
+    form {
+      height: 100%;
+      display: flex;
+      align-items: stretch;
+    }
+
+    textarea {
+      flex: 1; /* Allow the textarea to expand */
+      width: 100%; /* Ensure it fills the width */
+      resize: none; /* Disable manual resizing */
+      box-sizing: border-box; /* Account for padding and borders */
+      border: 1px solid #ccc; /* Standard input border style */
+      border-radius: 4px; /* Match the design */
+      padding: 5px; /* Inner padding for text */
+      font-family: inherit; /* Use consistent font */
+      font-size: inherit; /* Match the font size */
+      overflow: hidden; /* Hide overflow before it resizes */
+    }
+  </style>
+
 </head>
 <body>
 

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -9,6 +9,7 @@
       <tr>
         <th>Key</th>
         <th>Value</th>
+        <th>Original Translation</th>
       </tr>
     </thead>
     <tbody>
@@ -24,12 +25,17 @@
             <% end %>
           </td>
           <td>
-            <%= form_for translation&.presence || Moirai::Translation.new(key: key, locale: @locale, value: value), url: moirai_create_or_update_translation_path, method: :post do |f| %>
+            <%= form_for translation&.presence || Moirai::Translation.new(key: key, locale: @locale, value: value),
+                         url: moirai_create_or_update_translation_path,
+                         method: :post do |f| %>
               <%= f.hidden_field :key %>
               <%= f.hidden_field :locale %>
-              <%= f.text_field :value %>
+              <%= f.text_area :value, class: 'translation-textarea' %>
               <%= f.submit 'Update', style: 'display: none;' %>
             <% end %>
+          </td>
+          <td>
+            <%= I18n.translate_to_original(key, @locale) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/moirai/translation_files/show.html.erb
+++ b/app/views/moirai/translation_files/show.html.erb
@@ -35,7 +35,7 @@
             <% end %>
           </td>
           <td>
-            <%= I18n.translate_to_original(key, @locale) %>
+            <%= I18n.translate_without_moirai(key, @locale) %>
           </td>
         </tr>
       <% end %>

--- a/lib/i18n/extensions/i18n.rb
+++ b/lib/i18n/extensions/i18n.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module I18n
+  class << self
+    attr_accessor :original_backend
+  end
+
+  def self.translate_to_original(key, locale, **)
+    raise "Original backend is not set" unless original_backend
+
+    original_backend.translate(locale, key, **)
+  end
+end

--- a/lib/i18n/extensions/i18n.rb
+++ b/lib/i18n/extensions/i18n.rb
@@ -5,7 +5,7 @@ module I18n
     attr_accessor :original_backend
   end
 
-  def self.translate_to_original(key, locale, **)
+  def self.translate_without_moirai(key, locale, **)
     raise "Original backend is not set" unless original_backend
 
     original_backend.translate(locale, key, **)

--- a/lib/moirai.rb
+++ b/lib/moirai.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require "moirai/version"
+require "i18n/extensions/i18n"
+require "i18n/backend/moirai"
 require "moirai/engine"
 require "moirai/pull_request_creator"
-require "i18n/backend/moirai"
 
 module Moirai
   # Your code goes here...

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -9,8 +9,8 @@ module Moirai
     end
 
     config.after_initialize do
+      I18n.original_backend = I18n.backend
       if ActiveRecord::Base.connection.data_source_exists?("moirai_translations")
-        I18n.original_backend = I18n.backend
         I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Moirai.new, I18n.backend)
       else
         Rails.logger.warn("moirai disabled: tables have not been generated yet.")

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -10,6 +10,7 @@ module Moirai
 
     config.after_initialize do
       if ActiveRecord::Base.connection.data_source_exists?("moirai_translations")
+        I18n.original_backend = I18n.backend
         I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Moirai.new, I18n.backend)
       else
         Rails.logger.warn("moirai disabled: tables have not been generated yet.")

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -10,7 +10,7 @@ module Moirai
 
     config.after_initialize do
       I18n.original_backend = I18n.backend
-      if ActiveRecord::Base.connection.data_source_exists?("moirai_translations")
+      if ActiveRecord::Base.connection.data_source_exists?("moirai_translations") || ENV["RAILS_ENV"] == "test"
         I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Moirai.new, I18n.backend)
       else
         Rails.logger.warn("moirai disabled: tables have not been generated yet.")

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class I18nExtensionsTest < ActiveSupport::TestCase
+  test "it correctly translates using .translate and .translate_to_original" do
+    assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
+
+    Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")
+
+    assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
+    assert_equal "Italienisch", I18n.translate_to_original("locales.italian", :de)
+  end
+end

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -8,6 +8,8 @@ class I18nExtensionsTest < ActiveSupport::TestCase
     table_exists = ActiveRecord::Base.connection.data_source_exists?("moirai_translations")
     Rails.logger.debug("Database connection established: #{ActiveRecord::Base.connected?}")
     Rails.logger.debug("moirai_translations table exists: #{table_exists}")
+    Rails.logger.debug("Original backend is set: #{I18n.original_backend.present?}")
+    Rails.logger.debug(I18n.backend.inspect)
 
     # Ensure the table exists, or raise an error to debug further
     assert table_exists, "The moirai_translations table does not exist in the test database."

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -3,7 +3,15 @@
 require "test_helper"
 
 class I18nExtensionsTest < ActiveSupport::TestCase
-  test "it correctly translates using .translate and .translate_to_original" do
+  test "it correctly translates using .translate and .translate_without_moirai" do
+    # Debugging: Check if the database table exists
+    table_exists = ActiveRecord::Base.connection.data_source_exists?("moirai_translations")
+    Rails.logger.debug("Database connection established: #{ActiveRecord::Base.connected?}")
+    Rails.logger.debug("moirai_translations table exists: #{table_exists}")
+
+    # Ensure the table exists, or raise an error to debug further
+    assert table_exists, "The moirai_translations table does not exist in the test database."
+
     assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
 
     Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -8,6 +8,7 @@ class I18nExtensionsTest < ActiveSupport::TestCase
 
     Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")
 
+    assert_equal 1, Moirai::Translation.count
     assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
     assert_equal "Italienisch", I18n.translate_to_original("locales.italian", :de)
   end

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -4,16 +4,6 @@ require "test_helper"
 
 class I18nExtensionsTest < ActiveSupport::TestCase
   test "it correctly translates using .translate and .translate_without_moirai" do
-    # Debugging: Check if the database table exists
-    table_exists = ActiveRecord::Base.connection.data_source_exists?("moirai_translations")
-    Rails.logger.debug("Database connection established: #{ActiveRecord::Base.connected?}")
-    Rails.logger.debug("moirai_translations table exists: #{table_exists}")
-    Rails.logger.debug("Original backend is set: #{I18n.original_backend.present?}")
-    Rails.logger.debug(I18n.backend.inspect)
-
-    # Ensure the table exists, or raise an error to debug further
-    assert table_exists, "The moirai_translations table does not exist in the test database."
-
     assert_equal "Italienisch", I18n.t("locales.italian", locale: :de)
 
     Moirai::Translation.create!(locale: "de", key: "locales.italian", value: "Italianese")

--- a/test/i18n/i18n_test.rb
+++ b/test/i18n/i18n_test.rb
@@ -10,6 +10,6 @@ class I18nExtensionsTest < ActiveSupport::TestCase
 
     assert_equal 1, Moirai::Translation.count
     assert_equal "Italianese", I18n.t("locales.italian", locale: :de)
-    assert_equal "Italienisch", I18n.translate_to_original("locales.italian", :de)
+    assert_equal "Italienisch", I18n.translate_without_moirai("locales.italian", :de)
   end
 end


### PR DESCRIPTION
I have added the `i18n.translate_to_original` method that can be called throughout the application.

I have done this by adding an attribute accessor and extending I18n, and assigning the `original_backend` in the `after_initialize` callback. 

Hopefully this is a nice way to do it! I can then incorporate to the `check_translations_in_sync?` method in PR #48 