### PR TITLE
Fix route mounting and asset loading issues

### DIFF
--- a/lib/generators/moirai/install_generator.rb
+++ b/lib/generators/moirai/install_generator.rb
@@ -24,8 +24,6 @@ module Moirai
         end
       end
 
-      private
-
       def using_js_bundling?
         Rails.root.join("app/javascript/controllers").exist?
       end

--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -46,5 +46,9 @@ module Moirai
         require "moirai/translation_helper"
       end
     end
+
+    initializer "moirai.assets" do |app|
+      app.config.assets.precompile += %w[ moirai/application.css ]
+    end
   end
 end


### PR DESCRIPTION
### Why?

When trying to install the gem, I encountered issues while following the installation guide:

- The engine route wasn’t mounted due to a duplicated `private` declaration.
- Accessing the mounted route resulted in an error because the required assets weren’t loaded

### What?
- Removed the duplicated `private` declaration to ensure the engine route is properly mounted.
- Added `application.css` to the precompiled assets array to resolve the asset loading issue.

