### PR TITLE
Customize mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ By default, Moirai is mounted under `/moirai`. You can change it by specifying t
 config.root_path = '/my_translations'
 ```
 
-
 ### How to change translations
 
 If you mounted Moirai under "/moirai", head there and you will find a list of all the files containing texts that can be

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ bin/rails db:migrate
 
 ## Usage
 
+### Mount path
+
+By default, Moirai is mounted under `/moirai`. You can change it by specifying the `root_path` option in `config/initializers/moirai.rb`:
+
+```ruby
+# config/initializers/moirai.rb
+config.root_path = '/my_translations'
+```
+
+
 ### How to change translations
 
 If you mounted Moirai under "/moirai", head there and you will find a list of all the files containing texts that can be

--- a/app/assets/javascripts/moirai_translation_controller.js
+++ b/app/assets/javascripts/moirai_translation_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class MoiraiTranslationController extends Controller {
   static values = {
+    rootPath: { type: String, default: '/moirai' },
     key: String,
     locale: String
   }
@@ -13,7 +14,7 @@ export default class MoiraiTranslationController extends Controller {
   submit(event) {
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content
 
-    fetch('/moirai/translation_files', {
+    fetch(`${this.rootPathValue}/translation_files`, {
       method: 'POST',
       headers: {
         'X-CSRF-Token': csrfToken,

--- a/app/views/moirai/translation_files/_form.html.erb
+++ b/app/views/moirai/translation_files/_form.html.erb
@@ -1,9 +1,10 @@
-<span 
+<span
   contenteditable
   data-action="blur->moirai-translation#submit click->moirai-translation#click"
-  style="outline: 1px solid #1d9f74; min-width: 30px; display: inline-block; <%= 'color: red;' if is_missing_translation %>" 
+  style="outline: 1px solid #1d9f74; min-width: 30px; display: inline-block; <%= 'color: red;' if is_missing_translation %>"
   data-moirai-translation-key-value="<%= key %>"
   data-moirai-translation-locale-value="<%= locale %>"
-  data-controller="moirai-translation">
+  data-controller="moirai-translation"
+  data-moirai-translation-root-path-value="<%= Moirai.configuration.root_path %>">
   <%= value.to_s.gsub("<", "&lt;").gsub(">", "&gt;").html_safe %>
 </span>

--- a/lib/generators/moirai/install_generator.rb
+++ b/lib/generators/moirai/install_generator.rb
@@ -29,7 +29,12 @@ module Moirai
       end
 
       def mount_engine
-        route 'mount Moirai::Engine => "/moirai", as: "moirai"'
+        route "mount Moirai::Engine, at: Moirai.configuration.root_path, as: 'moirai'"
+      end
+
+      def add_initializer
+        say "Copying Moirai initializer"
+        template "initializers/moirai.tt", "config/initializers/moirai.rb"
       end
 
       private

--- a/lib/generators/moirai/templates/initializers/moirai.tt
+++ b/lib/generators/moirai/templates/initializers/moirai.tt
@@ -1,0 +1,5 @@
+# The values disaplayed here are the default ones. Change them to fit your needs.
+Moirai.configure do |config|
+  ## == Routing ==
+  config.root_path = '/moirai'
+end

--- a/lib/generators/moirai/templates/initializers/moirai.tt
+++ b/lib/generators/moirai/templates/initializers/moirai.tt
@@ -1,4 +1,4 @@
-# The values disaplayed here are the default ones. Change them to fit your needs.
+# The values displayed here are the default ones. Change them to fit your needs.
 Moirai.configure do |config|
   ## == Routing ==
   config.root_path = '/moirai'

--- a/lib/moirai.rb
+++ b/lib/moirai.rb
@@ -4,6 +4,7 @@ require "moirai/version"
 require "i18n/extensions/i18n"
 require "i18n/backend/moirai"
 require "moirai/engine"
+require "moirai/configuration"
 require "moirai/pull_request_creator"
 
 module Moirai

--- a/lib/moirai/configuration.rb
+++ b/lib/moirai/configuration.rb
@@ -1,0 +1,21 @@
+module Moirai
+  class Configuration
+    attr_accessor :root_path
+
+    def initialize
+      @root_path = '/moirai'
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configuration=(config)
+    @configuration = config
+  end
+
+  def self.configure
+    yield configuration
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Moirai::Engine => "/moirai", :as => "moirai"
+  mount Moirai::Engine => Moirai.configuration.root_path, :as => "moirai"
+
   root to: "home#index"
 end


### PR DESCRIPTION
### Why?

* Engine was mounted on `/morai`, and it wasn't possible to change it.
* Related to #54 

### What?

- `/morai` is the default root path
- Adds an initializer and configuration to allow developers to customize the mounted path in one place.
- Adds a value to stimulus controller to parameterize the mounted path
- Updates documentation
