### PR TITLE
Check if enable_inline_editing is present

### DIFF
--- a/lib/moirai/translation_helper.rb
+++ b/lib/moirai/translation_helper.rb
@@ -25,6 +25,8 @@ module ActionView::Helpers::TranslationHelper # rubocop:disable Lint/ConstantDef
   alias_method :t, :translate
 
   def moirai_edit_enabled?
+    return false unless Moirai.enable_inline_editing.present?
+
     Moirai.enable_inline_editing.call(params: defined?(params) ? (params || {}) : {})
   end
 


### PR DESCRIPTION
### Why
- Issue #69 
- Issue #66 
- It assumed enable_inline_editing option was set

### What
- Check enable_inline_editing presence before calling the block