### PR TITLE
Add SQLite table existence check

### DIFF
--- a/lib/moirai/engine.rb
+++ b/lib/moirai/engine.rb
@@ -12,7 +12,8 @@ module Moirai
 
     def self.on_sqlite?
       defined?(ActiveRecord::ConnectionAdapters::SQLite3Adapter) &&
-        ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
+        ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter) &&
+        ActiveRecord::Base.connection.table_exists?("moirai_translations")
     end
 
     def self.on_postgres?


### PR DESCRIPTION
The changes add a safety check for SQLite table existence.

The error is hard to replicate because Rails does not start if there are pending migrations anyway.